### PR TITLE
Fix exception on qse when no results returned.

### DIFF
--- a/src/NadekoBot/Modules/Utility/Quote/QuoteCommands.cs
+++ b/src/NadekoBot/Modules/Utility/Quote/QuoteCommands.cs
@@ -177,6 +177,14 @@ public partial class Utility
 
             var quotes = await _qs.SearchQuoteKeywordTextAsync(ctx.Guild.Id, keyword, textOrAuthor);
 
+            if (quotes.Count == 0)
+            {
+                await Response()
+                    .Error(strs.quotes_page_none)
+                    .SendAsync();
+                return;
+            }
+
             await Response()
                   .Paginated()
                   .Items(quotes)


### PR DESCRIPTION
This fixes qse throwing an index out of range exception the quote search returns an empty collection.