### PR TITLE
Add error message for missing guild permissions

### DIFF
--- a/src/NadekoBot/Modules/Administration/Role/RoleCommands.cs
+++ b/src/NadekoBot/Modules/Administration/Role/RoleCommands.cs
@@ -258,6 +258,9 @@ public partial class Administration
             if (!await CheckRoleHierarchy(role))
                 return;
 
+            if (!ctx.Guild.Features.HasRoleIcons)
+                await Response().Error(strs.userrole_icon_missing_permissions).SendAsync();
+
             if (string.IsNullOrWhiteSpace(iconUrl))
             {
                 await Response().Error(strs.userrole_icon_invalid).SendAsync();

--- a/src/NadekoBot/strings/responses/responses.en-US.json
+++ b/src/NadekoBot/strings/responses/responses.en-US.json
@@ -1205,6 +1205,7 @@
   "userrole_icon_success": "The icon for {0} has been saved.",
   "userrole_icon_fail": "Failed to set the role icon.",
   "userrole_icon_invalid": "The role icon cannot be empty.",
+  "userrole_icon_missing_permissions": "The server does not have permissions to use RoleIcons.",
   "userrole_role_not_exists": "That role doesn't exist.",
   "whos_playing_game": "{0} users are playing {1}",
   "schedule_list_title": "Scheduled Commands",


### PR DESCRIPTION
Current handling:
<img width="1724" height="315" alt="image" src="https://github.com/user-attachments/assets/18a06728-ef45-45b5-a73f-42ccee4c0832" />

New handling:
<img width="430" height="111" alt="image" src="https://github.com/user-attachments/assets/1cfee574-b89a-4b59-a96e-d0c9a69446b7" />
