### PR TITLE
Add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+### Description  
+Write here a summary of the issue you're having.  
+
+### Version  
+- Write here whether you're using public Nadeko or hosting one yourself.  
+- If you are hosting, write down:  
+  - The bot version (run the command .stats on Discord).  
+  - Your operating system and its version.  
+    - If you are on Windows, tell us whether you're using the updater version or the source version.
+    - If you are on Linux or OSX, tell us if you're hosting with tmux or pm2 or any other solution for managing processes.
+
+### Reproduction Steps  
+- Describe, in detail, the steps necessary to consistently reproduce the issue.  
+- Preferably write the entire procedure in step-by-step instructions.  
+
+### Expected Behavior  
+Write here the behavior you were expecting to get from the bot.  
+
+### Actual Behavior  
+Write here the behavior you actually got from the bot.  
+
+### Screenshots  
+Include here any relevant screenshot that illustrates the issue you're having or that might help pinpoint the cause of the bug.
+
+### Notes
+Write here anything else you want to say that wasn't covered on the previous topics.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,2 +1,11 @@
+---
+name: Feature Request
+about: Do not use this, go to https://nadeko.bot/suggest to make feature requests
+title: ''
+labels: Feature Request
+assignees: ''
+
+---
+
 GitHub is for bug reports only.  
 Please, head over to https://nadeko.bot/suggest to make feature requests.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,2 @@
+GitHub is for bug reports only.  
+Please, head over to https://nadeko.bot/suggest to make feature requests.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+### Description
+Write here a summary of the change(s) you're proposing and why this merge request would be a necessary or a nice addition to the project.
+Fixes # (issue)
+
+### Changes Proposed
+Describe, item by item, all changes you'd like to propose. Write them in a list, one proposition per line. For example:
+- Adds `DoStuff()` method to service X.
+- Changes `SomeMethod()` on service Y, so it can handle situation Z better.
+- Added a try/catch *somewhere*, so an exception is not thrown on the console when *something* happens.
+- Replaced `AMethod()` by `AnotherMethod()` in *some command* for performance reasons.
+
+### Type of change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+### Details
+Elaborate on the major and minor changes you've made to the source code. Try to explain why you've done something in a certain way.
+
+### How has this been tested?
+Please describe the tests that you ran to verify your changes.
+- [ ] Manually tested
+- [ ] Unit tests
+
+### Checklist:
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+
+### Screenshots
+If applicable, send us screenshots of the result of your changes.
+
+### Notes
+Write here additional considerations that weren't covered on the previous topics.


### PR DESCRIPTION
### Description
The project is missing templates to make contributions clearer and easier for people from the community 

### Changes Proposed
- Added bug_report.md
- Added feature_request.md
- Added PULL_REQUEST_TEMPLATE.md

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

### Details
These are based upon the previous gitlab ones

### How has this been tested?
Please describe the tests that you ran to verify your changes.
- [X] Manually tested
- [ ] Unit tests

### Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

### Screenshots
<img width="483" height="283" alt="image" src="https://github.com/user-attachments/assets/af9c1c66-9edf-453d-b8bf-c6b0fd488931" />

Issue templates

<img width="910" height="531" alt="image" src="https://github.com/user-attachments/assets/c10cabc4-1f74-46c2-8b99-423393c38825" />

Automatic PR template

### Notes
If you would like the feature request template to point to discord as well, lmk
